### PR TITLE
In OnTaskCompleted allow RuntimeError as well

### DIFF
--- a/src/wxasync.py
+++ b/src/wxasync.py
@@ -74,8 +74,8 @@ class WxAsyncApp(wx.App):
             # Note: exceptions from callbacks raise here
             # we just let them bubble as there is nothing we can do at this point
             _res = task.result()
-        except CancelledError:
-            # Cancelled because the window was destroyed, this is normal so ignore it
+        except (CancelledError, RuntimeError):
+           # Cancelled because the window was destroyed, this is normal so ignore it
             pass
         self.RunningTasks[task.obj].remove(task)
 


### PR DESCRIPTION
An RuntimeError exception was thrown each time I ran the wxasync example from the readme.md
(or any other that should be ok).  I suppose the error being thrown changes over versions of asyncio
Allowing this exception enables me to run examples without exceptions being thrown.