### PR TITLE
MainLoop: reset exit flag on exit

### DIFF
--- a/src/wxasync.py
+++ b/src/wxasync.py
@@ -38,6 +38,7 @@ class WxAsyncApp(wx.App):
                 await asyncio.sleep(0.005)
                 self.ProcessPendingEvents()
                 evtloop.ProcessIdle()
+            self.exiting = False
 
     def ExitMainLoop(self):
         self.exiting = True


### PR DESCRIPTION
This fixes a bug where the loop needs to run more than once,
e.g. because a window is shown before the main window of the application.

Workaround: manually reset .exiting to False.