### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Below is full example with AsyncBind, WxAsyncApp, and StartCoroutine:
 import wx
 from wxasync import AsyncBind, WxAsyncApp, StartCoroutine
 import asyncio
-from asyncio.events import get_event_loop
+from asyncio.events import new_event_loop
 import time
 
 class TestFrame(wx.Frame):
@@ -75,12 +75,12 @@ class TestFrame(wx.Frame):
         while True:
             self.edit_timer.SetLabel(time.strftime('%H:%M:%S'))
             await asyncio.sleep(0.5)
-            
-app = WxAsyncApp()
+
+loop = new_event_loop()
+app = WxAsyncApp(loop=loop)
 frame = TestFrame()
 frame.Show()
 app.SetTopWindow(frame)
-loop = get_event_loop()
 loop.run_until_complete(app.MainLoop())
 ```
 


### PR DESCRIPTION
### The minimal change
The example from `README.md` triggers the following warning in Python 3.10 on Windows 10:
```
wxasync_test.py:47: DeprecationWarning: There is no current event loop
  loop = get_event_loop()
```
See the [documentation](https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop) on the change in Python 3.10.

Calling `new_event_loop()` first and passing the event loop to `WxAsyncApp` fixes this problem:
```
loop = new_event_loop()
app = WxAsyncApp(loop=loop)
frame = TestFrame()
frame.Show()
app.SetTopWindow(frame)
loop = get_event_loop()
loop.run_until_complete(app.MainLoop())
```
Note that passing `loop` as a parameter is necessary, as otherwise the call of `get_event_loop()` in `WxAsyncApp.__init__` generates a second event loop. I have found no regressions of this change on my setup (I have not tested other python versions and OSes).

### The other option
As asyncio now recommends to manually manage loops as little as possible, I found the following to be nice and high-level:
```
async def main():
    app = WxAsyncApp()
    frame = TestFrame()
    frame.Show()
    app.SetTopWindow(frame)
    await app.MainLoop()

asyncio.run(main())
```
This way, the whole loop management is done by `asyncio` itself.

I would leave it up to you to decide which example you would prefer for the `README.md` file.