### PR TITLE
require python>=3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='wxasync',
       install_requires=[
           'wxpython',
       ],
+      python_requires=">=3.7",
       py_modules=['wxasync'],
       zip_safe=True,
 )


### PR DESCRIPTION
For example `asyncio.create_task()` is not available on Python 3.6